### PR TITLE
Update credential references in SIGPAC tools

### DIFF
--- a/base_wua_sigpac/static/python/load_shp.py
+++ b/base_wua_sigpac/static/python/load_shp.py
@@ -5,13 +5,13 @@ import subprocess
 
 # SHP to PostgreSQL (if the table exists records will be added, otherwise the table will be created and records added afterwards).
 #
-# Examples:
+# Examples (replace <USER> and <PASSWORD> with your PostgreSQL credentials):
 #
 # No filter:
-# python load_shp.py 127.0.0.1 5432 v10_cr_campo_cartagena_restored_20221229 odoo10moval odoo10movalEis51n1970molino1750 /tmp/rec_30045_2022_20220113.shp wua_gis_sigpac 25830
+# python load_shp.py 127.0.0.1 5432 v10_cr_campo_cartagena_restored_20221229 <USER> <PASSWORD> /tmp/rec_30045_2022_20220113.shp wua_gis_sigpac 25830
 #
 # Filter (last argument):
-# python load_shp.py 127.0.0.1 5432 v10_cr_campo_cartagena_restored_20221229 odoo10moval odoo10movalEis51n1970molino1750 /tmp/rec_30045_2022_20220113.shp wua_gis_sigpac 25830 '"poligono">=529 and "poligono"<=539'
+# python load_shp.py 127.0.0.1 5432 v10_cr_campo_cartagena_restored_20221229 <USER> <PASSWORD> /tmp/rec_30045_2022_20220113.shp wua_gis_sigpac 25830 '"poligono">=529 and "poligono"<=539'
 
 num_args = len(sys.argv)
 if num_args == 9 or num_args == 10:
@@ -41,7 +41,7 @@ if num_args == 9 or num_args == 10:
 else:
     print 'SHP to PostgreSQL, incorrect sintax. Use:\npython load_shp.py {host} {port} {dbname} {user} {password} {shp} {table} {srs} [{\'condition\'}]'
     print '\nExample 1 (no filter):\n'
-    print 'python load_shp.py 127.0.0.1 5432 v10_cr_campo_cartagena_restored_20221229 odoo10moval odoo10movalEis51n1970molino1750 /tmp/rec_30045_2022_20220113.shp wua_gis_sigpac 25830'
+    print 'python load_shp.py 127.0.0.1 5432 v10_cr_campo_cartagena_restored_20221229 <USER> <PASSWORD> /tmp/rec_30045_2022_20220113.shp wua_gis_sigpac 25830'
     print '\nExample 2 (with filter):\n'
-    print 'python load_shp.py 127.0.0.1 5432 v10_cr_campo_cartagena_restored_20221229 odoo10moval odoo10movalEis51n1970molino1750 /tmp/rec_30045_2022_20220113.shp wua_gis_sigpac 25830 \'"poligono">=529 and "poligono"<=539\''
+    print 'python load_shp.py 127.0.0.1 5432 v10_cr_campo_cartagena_restored_20221229 <USER> <PASSWORD> /tmp/rec_30045_2022_20220113.shp wua_gis_sigpac 25830 \'"poligono">=529 and "poligono"<=539\''
     sys.exit(255)

--- a/base_wua_sigpac/static/python/load_sigpac.py
+++ b/base_wua_sigpac/static/python/load_sigpac.py
@@ -6,16 +6,16 @@ import psycopg2
 
 # SHP to SIGPAC table (if the table exists records will be added, otherwise the table will be created and records added afterwards).
 #
-# Examples:
+# Examples (replace <USER> and <PASSWORD> with your PostgreSQL credentials):
 #
 # 1. One SHP:
-# python load_sigpac.py 127.0.0.1 5432 v10_cr_campo_cartagena_restored_20221229 odoo10moval odoo10movalEis51n1970molino1750 /tmp/rec_30045_2022_20220113.shp 25830
+# python load_sigpac.py 127.0.0.1 5432 v10_cr_campo_cartagena_restored_20221229 <USER> <PASSWORD> /tmp/rec_30045_2022_20220113.shp 25830
 #
 # 2. Two SHP:
-# python load_sigpac.py 127.0.0.1 5432 v10_cr_campo_cartagena_restored_20221229 odoo10moval odoo10movalEis51n1970molino1750 /tmp/rec_03142_2022_20220113.shp#/tmp/rec_30045_2022_20220113.shp 25830
+# python load_sigpac.py 127.0.0.1 5432 v10_cr_campo_cartagena_restored_20221229 <USER> <PASSWORD> /tmp/rec_03142_2022_20220113.shp#/tmp/rec_30045_2022_20220113.shp 25830
 #
 # 3. Three SHP, a SHP with filter:
-# python load_sigpac.py 127.0.0.1 5432 v10_cr_campo_cartagena_restored_20221229 odoo10moval odoo10movalEis51n1970molino1750 '/tmp/rec_03142_2022_20220113.shp#/tmp/rec_30045_2022_20220113.shp("poligono">=529 and "poligono"<=539)#/tmp/rec_30045_2022_20220113.shp' 25830
+# python load_sigpac.py 127.0.0.1 5432 v10_cr_campo_cartagena_restored_20221229 <USER> <PASSWORD> '/tmp/rec_03142_2022_20220113.shp#/tmp/rec_30045_2022_20220113.shp("poligono">=529 and "poligono"<=539)#/tmp/rec_30045_2022_20220113.shp' 25830
 
 num_args = len(sys.argv)
 if num_args == 8:
@@ -68,9 +68,9 @@ if num_args == 8:
 else:
     print 'SHP to SIGPAC table, incorrect sintax. Use:\npython load_sigpac.py {host} {port} {dbname} {user} {password} {shp_list_with_optional_condition} {srs}'
     print '\nExample 1 (one SHP):\n'
-    print 'python load_sigpac.py 127.0.0.1 5432 v10_cr_campo_cartagena_restored_20221229 odoo10moval odoo10movalEis51n1970molino1750 /tmp/rec_30045_2022_20220113.shp 25830'
+    print 'python load_sigpac.py 127.0.0.1 5432 v10_cr_campo_cartagena_restored_20221229 <USER> <PASSWORD> /tmp/rec_30045_2022_20220113.shp 25830'
     print '\nExample 2 (two SHP):\n'
-    print 'python load_sigpac.py 127.0.0.1 5432 v10_cr_campo_cartagena_restored_20221229 odoo10moval odoo10movalEis51n1970molino1750 /tmp/rec_03142_2022_20220113.shp#/tmp/rec_30045_2022_20220113.shp 25830'
+    print 'python load_sigpac.py 127.0.0.1 5432 v10_cr_campo_cartagena_restored_20221229 <USER> <PASSWORD> /tmp/rec_03142_2022_20220113.shp#/tmp/rec_30045_2022_20220113.shp 25830'
     print '\nExample 3 (three SHP, a SHP with filter):\n'
-    print 'python load_sigpac.py 127.0.0.1 5432 v10_cr_campo_cartagena_restored_20221229 odoo10moval odoo10movalEis51n1970molino1750 \'/tmp/rec_03142_2022_20220113.shp#/tmp/rec_30045_2022_20220113.shp("poligono">=529 and "poligono"<=539)#/tmp/rec_30045_2022_20220113.shp\' 25830'
+    print 'python load_sigpac.py 127.0.0.1 5432 v10_cr_campo_cartagena_restored_20221229 <USER> <PASSWORD> \'/tmp/rec_03142_2022_20220113.shp#/tmp/rec_30045_2022_20220113.shp("poligono">=529 and "poligono"<=539)#/tmp/rec_30045_2022_20220113.shp\' 25830'
     sys.exit(255)


### PR DESCRIPTION
## Summary
- clarify example comments in `load_sigpac.py`
- clarify example comments in `load_shp.py`
- use `<USER>` and `<PASSWORD>` placeholders instead of hard-coded credentials

## Testing
- `python -m py_compile base_wua_sigpac/static/python/load_sigpac.py base_wua_sigpac/static/python/load_shp.py` *(fails: Missing parentheses in call to 'print')*


------
https://chatgpt.com/codex/tasks/task_e_68402b6ef838832d8ed8d0a34a442685