### PR TITLE
Sanitize docs without helper

### DIFF
--- a/wua_remotecontrol_rest_batchline_irriweb/README.rst
+++ b/wua_remotecontrol_rest_batchline_irriweb/README.rst
@@ -23,9 +23,13 @@ If the integration of frames for readings, consumptions and scheduing
 is enabled, then it is mandatory to have the following PHP on a
 web server: framebatchlineirriweb.php.
 
- Example::
+Example::
 
     http://127.0.0.1/framebatchlineirriweb.php
+
+The default configuration included in this repository contains
+placeholder values only. Actual connection parameters should be
+configured through the Odoo settings before using the module.
 
 Credits
 =======

--- a/wua_remotecontrol_rest_batchline_irriweb/data/wua_irrigation_config_settings_data.xml
+++ b/wua_remotecontrol_rest_batchline_irriweb/data/wua_irrigation_config_settings_data.xml
@@ -5,7 +5,7 @@
 
         <record id="param_ir_values_url_remotecontrol_rest_batchline"
                 model="ir.values" forcecreate="False">
-            <field name="value">S&apos;http://78.136.122.3:20080&apos;&#10;p1&#10;.</field>
+            <field name="value">S'-'&#10;p1&#10;.</field>
             <field name="key2"></field>
             <field name="key">default</field>
             <field name="model">wua.irrigation.configuration</field>
@@ -14,7 +14,7 @@
 
         <record id="param_ir_values_url_remotecontrol_rest_username_batchline"
                 model="ir.values" forcecreate="False">
-            <field name="value">S&apos;MOVAL&apos;&#10;p1&#10;.</field>
+            <field name="value">S'-'&#10;p1&#10;.</field>
             <field name="key2"></field>
             <field name="key">default</field>
             <field name="model">wua.irrigation.configuration</field>
@@ -23,7 +23,7 @@
 
         <record id="param_ir_values_url_remotecontrol_rest_password_batchline"
                 model="ir.values" forcecreate="False">
-            <field name="value">S&apos;MOVALArgos.2019&apos;&#10;p1&#10;.</field>
+            <field name="value">S'-'&#10;p1&#10;.</field>
             <field name="key2"></field>
             <field name="key">default</field>
             <field name="model">wua.irrigation.configuration</field>
@@ -32,7 +32,7 @@
 
         <record id="param_ir_values_url_remotecontrol_application_batchline"
                 model="ir.values" forcecreate="False">
-            <field name="value">S&apos;http://78.136.122.3:8080/demo&apos;&#10;p1&#10;.</field>
+            <field name="value">S'-'&#10;p1&#10;.</field>
             <field name="key2"></field>
             <field name="key">default</field>
             <field name="model">wua.irrigation.configuration</field>
@@ -149,7 +149,7 @@
 
         <record id="param_ir_values_php_frame_client"
                 model="ir.values" forcecreate="False">
-            <field name="value">S&apos;MOVAL&apos;&#10;p1&#10;.</field>
+            <field name="value">S'-'&#10;p1&#10;.</field>
             <field name="key2"></field>
             <field name="key">default</field>
             <field name="model">wua.irrigation.configuration</field>
@@ -158,7 +158,7 @@
 
         <record id="param_ir_values_php_frame_accesskey"
                 model="ir.values" forcecreate="False">
-            <field name="value">S&apos;QjlEMDg0MTAxQzMwNDQyOUIwNzcwRDVENTMwNDY3NDI=&apos;&#10;p1&#10;.</field>
+            <field name="value">S'-'&#10;p1&#10;.</field>
             <field name="key2"></field>
             <field name="key">default</field>
             <field name="model">wua.irrigation.configuration</field>
@@ -167,7 +167,7 @@
 
         <record id="param_ir_values_php_frame_secretkey"
                 model="ir.values" forcecreate="False">
-            <field name="value">S&apos;MDMxNkU4QTc2OTYyNDVGRUJBMjM0OEQ0QTZCOUI4MzY=&apos;&#10;p1&#10;.</field>
+            <field name="value">S'-'&#10;p1&#10;.</field>
             <field name="key2"></field>
             <field name="key">default</field>
             <field name="model">wua.irrigation.configuration</field>


### PR DESCRIPTION
## Summary
- scrub configuration credentials from XML
- remove `get_param` helper and revert to `ir.values` lookups
- drop environment variable docs and note placeholders

## Testing
- `python -m py_compile $(git ls-files 'wua_remotecontrol_rest_batchline_irriweb/**/*.py')`
- `flake8 wua_remotecontrol_rest_batchline_irriweb` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402cd6e640832d8491edcaa9c85d4f